### PR TITLE
Add ssl support for kcp

### DIFF
--- a/include/kcp.hpp
+++ b/include/kcp.hpp
@@ -650,6 +650,9 @@ namespace moon
                 });
             }
         public:
+            using lowest_layer_type = connection;
+            using executor_type = asio::any_io_executor;
+
             connection(udp::socket* sock, uint32_t conv, udp::endpoint& endpoint, bool isserver)
                 : isserver_(isserver)
                 , conv_(conv)
@@ -682,9 +685,19 @@ namespace moon
                 }
             }
 
-            asio::any_io_executor get_executor()
+            const executor_type& get_executor() noexcept
             {
                 return sock_->get_executor();
+            }
+
+            lowest_layer_type& lowest_layer()
+            {
+                return *this;
+            }
+
+            const lowest_layer_type& lowest_layer() const
+            {
+                return *this;
             }
 
             /*
@@ -711,6 +724,13 @@ namespace moon
 
             template<typename ConstBuffer, typename WriteHandler>
             auto async_write(const ConstBuffer& buffer, WriteHandler&& handler)
+            {
+                return asio::async_initiate<WriteHandler, void(const std::error_code&, size_t)>(
+                    initiate_async_write(this), handler, buffer);
+            }
+
+            template<typename ConstBuffer, typename WriteHandler>
+            auto async_write_some(const ConstBuffer& buffer, WriteHandler&& handler)
             {
                 return asio::async_initiate<WriteHandler, void(const std::error_code&, size_t)>(
                     initiate_async_write(this), handler, buffer);


### PR DESCRIPTION
为kcp添加ssl支持，需要为kcp库提供一些小修改  
以下是ssl的例子
**server.cpp**
```cpp
#include <iostream>
#include <memory>
#include <string_view>
#include <asio/ssl.hpp>
#include "kcp.hpp"

constexpr uint8_t connect_key[32] = { 49, 194, 61, 231, 161, 216, 31, 60, 230, 26, 13, 25, 211, 185, 93, 67, 118, 28, 49, 220, 184, 71, 20, 228, 4, 24, 36, 205, 222, 99, 240, 152 };
constexpr size_t buffer_size = 8192;
std::string magic = std::string{(char*)connect_key, 32};
asio::ssl::context ssl_context(asio::ssl::context::tlsv13_server);

asio::awaitable<void> start_kcp_connection(moon::kcp::connection_ptr socket)
{
    std::string string_buffer;
    string_buffer.resize(2048);
    asio::ssl::stream<moon::kcp::connection&> ssl_socket(*socket, ssl_context);
    try {
        co_await ssl_socket.async_handshake(asio::ssl::stream_base::server, asio::use_awaitable);
        for (;;) {
            co_await ssl_socket.async_write_some(asio::buffer("hello!"), asio::use_awaitable);
            size_t size = co_await ssl_socket.async_read_some(asio::buffer(string_buffer), asio::use_awaitable);
            std::cout << std::string_view{string_buffer.c_str(), size} << '\n';
        }
    } catch(const std::system_error& e) {
        std::cerr << e.code().message() << '\n';
    }
    co_return;
}

asio::awaitable<void> start_kcp_server()
{
    auto executor = co_await asio::this_coro::executor;
    moon::kcp::acceptor acceptor(executor, asio::ip::udp::endpoint(asio::ip::udp::v4(), 50000), magic);

    for (;;) {
        auto socket = co_await acceptor.async_accept(asio::use_awaitable);
        asio::co_spawn(executor, start_kcp_connection(std::move(socket)), asio::detached);
    }
    co_return;
}

int main() {
    asio::io_context io_context;

    ssl_context.use_certificate_file("certs.pem", asio::ssl::context::pem);
    ssl_context.use_private_key_file("key.pem", asio::ssl::context::pem);

    asio::signal_set signals(io_context, SIGINT, SIGTERM);
    signals.async_wait([&](auto, auto) { io_context.stop(); });

    asio::co_spawn(io_context, start_kcp_server(), asio::detached);

    io_context.run();

    return 0;
}

```
**client.cpp**
```cpp
#include <iostream>
#include <memory>
#include <string_view>
#include <asio/ssl.hpp>
#include "kcp.hpp"

constexpr uint8_t connect_key[32] = { 49, 194, 61, 231, 161, 216, 31, 60, 230, 26, 13, 25, 211, 185, 93, 67, 118, 28, 49, 220, 184, 71, 20, 228, 4, 24, 36, 205, 222, 99, 240, 152 };
constexpr size_t buffer_size = 8192;
std::string magic = std::string{(char*)connect_key, 32};
asio::ssl::context ssl_context(asio::ssl::context::tlsv13_client);

asio::awaitable<void> start_kcp_client(asio::io_context& io_context) {
    auto executor = co_await asio::this_coro::executor;
    auto [ec, socket] = co_await moon::kcp::async_connect(executor, asio::ip::udp::endpoint(asio::ip::address::from_string("127.0.0.1"), 50000), magic);
    if (ec) {
        std::cerr << ec.message() << '\n';
        co_return;
    }

    std::string string_buffer;
    string_buffer.resize(2048);
    asio::ssl::stream<moon::kcp::connection&> ssl_socket(*socket, ssl_context);
    co_await ssl_socket.async_handshake(asio::ssl::stream_base::client, asio::use_awaitable);
    for (;;) {
        size_t size = co_await ssl_socket.async_read_some(asio::buffer(string_buffer), asio::use_awaitable);
        std::cout << std::string_view{string_buffer.c_str(), size} << '\n';
        co_await ssl_socket.async_write_some(asio::buffer("hello!"), asio::use_awaitable);
    }
    co_return;
}

int main() {
    asio::io_context io_context;

    ssl_context.set_default_verify_paths();
    // ssl_context.set_verify_mode(asio::ssl::verify_none);

    asio::signal_set signals(io_context, SIGINT, SIGTERM);
    signals.async_wait([&](auto, auto) { io_context.stop(); });

    asio::co_spawn(io_context, start_kcp_client(io_context), asio::detached);
    io_context.run();

    return 0;
}

```
希望大佬能够帮忙merge一下，谢谢！